### PR TITLE
fix: guard against unparseable OCSP responses causing a crash

### DIFF
--- a/swift/zsign.mm
+++ b/swift/zsign.mm
@@ -343,9 +343,20 @@ int checkCert(
 		NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
 		if (httpResponse.statusCode == 200 && data) {
 			const void *respBytes = [data bytes];
-			OCSP_RESPONSE *resp;
-			d2i_OCSP_RESPONSE(&resp, (const unsigned char**)&respBytes, data.length);
+			OCSP_RESPONSE *resp = nullptr;
+			if (!d2i_OCSP_RESPONSE(&resp, (const unsigned char**)&respBytes, data.length) || !resp) {
+				completionHandler(2, nil, @"Unable to parse OCSP response");
+				OCSP_CERTID_free(cert_id);
+				if (resp) OCSP_RESPONSE_free(resp);
+				return;
+			}
 			OCSP_BASICRESP *basic = OCSP_response_get1_basic(resp);
+			if (!basic) {
+				completionHandler(2, nil, @"Unable to parse OCSP basic response");
+				OCSP_CERTID_free(cert_id);
+				OCSP_RESPONSE_free(resp);
+				return;
+			}
 			ASN1_TIME *expirationDateAsn1 = X509_get_notAfter(cert);
 			NSString *fullDateString = [NSString stringWithFormat:@"20%s", expirationDateAsn1->data];
 			


### PR DESCRIPTION
## Summary
`d2i_OCSP_RESPONSE`'s return value was never checked in `checkCert`'s
OCSP completion handler. When the server's response didn't parse as
valid DER, `resp` was left uninitialized and immediately passed to
`OCSP_response_get1_basic`, dereferencing garbage stack memory
(EXC_BAD_ACCESS).

## Test plan
- Verified crash resolved on with Feather app. App crashes when `Check Revokage` is triggered or when more than one certificate is added.